### PR TITLE
Update blog permissions and use socket for MySQL

### DIFF
--- a/playbooks/add_blog.yaml
+++ b/playbooks/add_blog.yaml
@@ -43,12 +43,13 @@
     - name: Move WordPress from ./wordpress to ./public_html
       command: mv /var/www/{{ blog_url }}/wordpress /var/www/{{ blog_url }}/public_html
 
-    - name: Set correct permissions for the folders
+      # 700 for folders and 600 for files
+    - name: Set permissions for the blog's files and folders
       ansible.builtin.file:
         path: /var/www/{{ blog_url }}
         state: directory
         recurse: yes
-        mode: 0755
+        mode: a=-rwx,u+rwX
         owner: '{{ blog_name }}'
         group: '{{ blog_name }}'
 
@@ -58,23 +59,27 @@
         return_content: yes
       register: salts
 
+      # Set the wp-config.php file to be read-only
     - name: Copy wp-config.php to /var/www/{{ blog_url }}/public_html
       template:
         src: ../templates/wp-config.php.j2
         dest: /var/www/{{ blog_url }}/public_html/wp-config.php
-        mode: 0444
+        mode: 0400
         owner: '{{ blog_name }}'
         group: '{{ blog_name }}'
 
     - name: Create database
       mysql_db:
         name: '{{ blog_name }}'
+        login_unix_socket: /run/mysqld/mysqld.sock
         state: present
 
+      # We'll connect to MySQL using the unix_socket so no password is required
     - name: Create mysql user
       mysql_user:
         name: '{{ blog_name }}'
-        # password: '{{ lookup('password', '/tmp/passwordfile length=8 chars=digits') }}'
+        login_unix_socket: /run/mysqld/mysqld.sock
+        plugin: unix_socket
         password: ''
         priv: '{{ blog_name }}.*:ALL'
 

--- a/playbooks/remove_blog.yaml
+++ b/playbooks/remove_blog.yaml
@@ -8,11 +8,13 @@
     - name: Delete database
       mysql_db:
         name: '{{ blog_name }}'
+        login_unix_socket: /run/mysqld/mysqld.sock
         state: absent
 
     - name: Delete mysql user
       mysql_user:
         name: '{{ blog_url }}'
+        login_unix_socket: /run/mysqld/mysqld.sock
         state: absent
         priv: '{{ blog_name }}.*:ALL'
 

--- a/playbooks/secure_sql.yaml
+++ b/playbooks/secure_sql.yaml
@@ -1,51 +1,29 @@
 ---
   - hosts: all
-    vars:
-      # Generate a password for MySQL
-      mysql_root_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits length=20') }}"
-
     tasks:
-    - name: Check that /root/.my.cnf exists
-      stat:
-        path: /root/.my.cnf
-      register: sql_secured
 
-    - name: Copy mysql root config file
-      template:
-        src: ../templates/my.cnf.j2
-        dest: /root/.my.cnf
-      when: not sql_secured.stat.exists
-
-    - name: Read password from file
-      shell: grep -oP '(?<=password=)[^.]*' /root/.my.cnf
-      register: mysql_password
-      when: not sql_secured.stat.exists
-
-    - name: Update mysql root password
+    - name: Set root to login to MySQL using the unix_socket
       mysql_user:
         name: root
-        config_file: /root/.my.cnf
-        password: '{{ mysql_password.stdout }}'
-        login_unix_socket: /var/run/mysqld/mysqld.sock
+        plugin: unix_socket
+        password: ''
+        login_unix_socket: /run/mysqld/mysqld.sock
         priv: '*.*:ALL,GRANT'
-        check_implicit_admin: yes
-      when: not sql_secured.stat.exists
 
     - name: Remove anonymous user from mysql
       mysql_user:
         name: ''
         host_all: yes
+        login_unix_socket: /run/mysqld/mysqld.sock
         state: absent
-      when: not sql_secured.stat.exists
 
     - name: Remove the test database from mysql
       mysql_db:
         db: test
+        login_unix_socket: /run/mysqld/mysqld.sock
         state: absent
-      when: not sql_secured.stat.exists
 
     - name: Restart service mariadb
       service:
         name: mariadb
         state: restarted
-      when: not sql_secured.stat.exists


### PR DESCRIPTION
- Set the blog's file permissions to 600 and folders to 700.
  This is fine since we run the blog with it's own user and group.
- Log into MySQL using the ´unix_socket´ for both root and the blog's users.